### PR TITLE
Add support for channel param

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ ticket_swap_payment_przelewy24:
     crc:         Your CRC key
     test:        true/false   # Default true
     report_url:  https://host/webhook/przelewy24
+    channel:     1 # Default 63
 ```
+
+The 'channel' field is optional and is must be the sum of the values specified in the [przelewy24 documentation](http://www.przelewy24.pl/eng/storage/app/media/pobierz/Instalacja/przelewy24_specification.pdf)
+for the parameter 'p24_channel'. Default value will be 63 (which enables all the payment channels).
 
 Make sure you set the `return_url` in the `predefined_data` for every payment method you enable:
 ````php

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -39,6 +39,10 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('logger')
                     ->defaultTrue()
                 ->end()
+                ->integerNode('channel')
+                    ->treatNullLike(63)
+                    ->defaultValue(63)
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/TicketSwapPaymentPrzelewy24Extension.php
+++ b/src/DependencyInjection/TicketSwapPaymentPrzelewy24Extension.php
@@ -30,6 +30,7 @@ class TicketSwapPaymentPrzelewy24Extension extends Extension
         $container->setParameter('ticket_swap_payment_przelewy24.crc', $config['crc']);
         $container->setParameter('ticket_swap_payment_przelewy24.test', $config['test']);
         $container->setParameter('ticket_swap_payment_przelewy24.report_url', $config['report_url']);
+        $container->setParameter('ticket_swap_payment_przelewy24.channel', $config['channel']);
 
         /**
          * When logging is disabled, remove logger and setLogger calls

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,6 +14,7 @@
         <parameter key="ticket_swap_payment_przelewy24.crc" />
         <parameter key="ticket_swap_payment_przelewy24.test" />
         <parameter key="ticket_swap_payment_przelewy24.report_url" />
+        <parameter key="ticket_swap_payment_przelewy24.channel" />
     </parameters>
 
     <services>
@@ -40,6 +41,9 @@
             </call>
             <call method="setTestMode">
                 <argument>%ticket_swap_payment_przelewy24.test%</argument>
+            </call>
+            <call method="setChannel">
+                <argument>%ticket_swap_payment_przelewy24.channel%</argument>
             </call>
         </service>
 


### PR DESCRIPTION
This PR adds an optional configuration parameter for the bundle so we can specify the payments channels that we want enabled.

The default value will be 63 (all the payment options available) which is the same behaviour as when the parameter is not sent in the request.

This parameter will be used to initialize the Gateway.

See: https://github.com/TicketSwap/omnipay-przelewy24/pull/3

The use of the 'p24_channel' param is explained at http://www.przelewy24.pl/eng/storage/app/media/pobierz/Instalacja/przelewy24_specification.pdf

![image](https://cloud.githubusercontent.com/assets/736095/23958185/8932d576-09a1-11e7-9f92-5464d18e16f9.png)

